### PR TITLE
Fix clang warnings about missing overrides

### DIFF
--- a/analyses/check_nsw_plugin.hpp
+++ b/analyses/check_nsw_plugin.hpp
@@ -14,7 +14,7 @@ class CheckNSWPlugin : public InstrPlugin
     public:
         bool supports(const std::string& query) override;
         std::string query(const std::string& query,
-                const std::vector<llvm::Value *>& operands) {
+                const std::vector<llvm::Value *>& operands) override {
             if (query == "canOverflow") {
                 assert(operands.size() == 1 && "Wrong number of operands");
                 return canOverflow(operands[0]);

--- a/analyses/dg_points_to_plugin.hpp
+++ b/analyses/dg_points_to_plugin.hpp
@@ -88,7 +88,7 @@ private:
 public:
     bool supports(const std::string& query) override;
     std::string query(const std::string& query,
-                      const std::vector<llvm::Value *>& operands)
+                      const std::vector<llvm::Value *>& operands) override
     {
         if (query == "isValidPointer") {
             assert(operands.size() == 2 && "Wrong number of operands");

--- a/analyses/infinite_loops_plugin.hpp
+++ b/analyses/infinite_loops_plugin.hpp
@@ -17,7 +17,7 @@ private:
 public:
     bool supports(const std::string& query) override;
     std::string query(const std::string& query,
-            const std::vector<llvm::Value *>& operands)
+            const std::vector<llvm::Value *>& operands) override
     {
         if (query == "isInfinite") {
             assert(operands.size() == 1 && "Wrong number of operands");

--- a/analyses/llvm_points_to_plugin.hpp
+++ b/analyses/llvm_points_to_plugin.hpp
@@ -22,7 +22,7 @@ class LLVMPointsToPlugin : public InstrPlugin {
 public:
     bool supports(const std::string& query) override;
     std::string query(const std::string& query,
-                      const std::vector<llvm::Value *>& operands)
+                      const std::vector<llvm::Value *>& operands) override
     {
         if (query == "isValidPointer") {
             assert(operands.size() == 2 && "Wrong number of operands");

--- a/analyses/predator_plugin.hpp
+++ b/analyses/predator_plugin.hpp
@@ -99,7 +99,7 @@ public:
     bool supports(const std::string& query) override;
 
     std::string query(const std::string& query,
-                      const std::vector<llvm::Value *>& operands) {
+                      const std::vector<llvm::Value *>& operands) override {
 
         if (!predatorSuccess) {
             return "maybe";

--- a/analyses/range_analysis_plugin.hpp
+++ b/analyses/range_analysis_plugin.hpp
@@ -30,7 +30,7 @@ private:
 public:
     bool supports(const std::string& query) override;
     std::string query(const std::string& query,
-                      const std::vector<llvm::Value *>& operands)
+                      const std::vector<llvm::Value *>& operands) override
     {
         if (query == "canOverflow") {
             assert(operands.size() == 1 && "Wrong number of operands");

--- a/analyses/value_relations_plugin.hpp
+++ b/analyses/value_relations_plugin.hpp
@@ -22,7 +22,7 @@ public:
     }
 
     std::string query(const std::string& query,
-                      const std::vector<llvm::Value *>& operands)
+                      const std::vector<llvm::Value *>& operands) override
     {
         if (query == "isValidPointer") {
             assert(operands.size() == 2 && "Wrong number of operands");


### PR DESCRIPTION
I have also fixed some clang warnings while preparing the LLVM 10 PR.