### PR TITLE
bootstrap-json.sh: Use the latest jsoncpp

### DIFF
--- a/bootstrap-json.sh
+++ b/bootstrap-json.sh
@@ -10,10 +10,6 @@ cd `dirname $`
 if [ ! -d jsoncpp ]; then
 	# checkout jsoncpp directory
 	git clone https://github.com/open-source-parsers/jsoncpp
-	# FIXME: until a bug in building is fixed in the upstream
-	cd jsoncpp
-	git checkout c51d718ead5b
-	cd -
 fi
 
 cd jsoncpp


### PR DESCRIPTION
The older version is not compatible with clang 10.
See: open-source-parsers/jsoncpp#1021

This reverts commit 61f9e8b9cbe99777c4f4b582369d65845c9d88d3.

Part of staticafi/symbiotic#147