### PR TITLE
llvm11: llvm::CallSite has been removed

### DIFF
--- a/analyses/ra/RangeAnalysis.cpp
+++ b/analyses/ra/RangeAnalysis.cpp
@@ -345,15 +345,20 @@ void InterProceduralRA::MatchParametersAndReturnValues(Function &F,
 
 		Instruction *caller = cast<Instruction>(U);
 
+#if LLVM_VERSION_MAJOR >= 8
+		CallBase &CS = cast<CallBase>(*caller);
+#else
 		CallSite CS(caller);
+#endif
+
 		if (!CS.isCallee(const_cast<const Use *>(&(*UI))))
 			continue;
 
 		// Iterate over the real parameters and put them in the data structure
-		CallSite::arg_iterator AI;
-		CallSite::arg_iterator EI;
+		auto AI = CS.arg_begin();
+		auto EI = CS.arg_end();
 
-		for (i = 0, AI = CS.arg_begin(), EI = CS.arg_end(); AI != EI; ++i, ++AI)
+		for (i = 0; AI != EI; ++i, ++AI)
 			Parameters[i].second = *AI;
 
 		// // Do the interprocedural construction of CG

--- a/analyses/ra/RangeAnalysis.h
+++ b/analyses/ra/RangeAnalysis.h
@@ -47,7 +47,9 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/IR/ConstantRange.h"
+#if LLVM_VERSION_MAJOR < 8
 #include "llvm/IR/CallSite.h"
+#endif
 #include "llvm/IR/InstIterator.h"
 #include "llvm/Support/Process.h"
 #include <deque>


### PR DESCRIPTION
See: https://reviews.llvm.org/D78794

I have missed this in #51, because the compiler always pulled `llvm/IR/CallSite.h` from my system LLVM 10 installation.