### PR TITLE
Handle _exit and _Exit in memsafety and memcleanup

### DIFF
--- a/instrumentations/memsafety/config-marker-memcleanup.json
+++ b/instrumentations/memsafety/config-marker-memcleanup.json
@@ -179,6 +179,38 @@
                 "where": "before",
                 "in": "*"
             },
+            {
+                "findInstructions": [
+                {
+                    "returnValue": "*",
+                    "instruction": "call",
+                    "operands": ["<val>", "_exit"]
+                }
+                ],
+                "newInstruction": {
+                    "returnValue": "*",
+                    "instruction": "call",
+                    "operands": ["__INSTR_mark_exit"]
+                },
+                "where": "before",
+                "in": "*"
+            },
+            {
+                "findInstructions": [
+                {
+                    "returnValue": "*",
+                    "instruction": "call",
+                    "operands": ["<val>", "_Exit"]
+                }
+                ],
+                "newInstruction": {
+                    "returnValue": "*",
+                    "instruction": "call",
+                    "operands": ["__INSTR_mark_exit"]
+                },
+                "where": "before",
+                "in": "*"
+            },
 	    {
                 "findInstructions": [
                 {

--- a/instrumentations/memsafety/config-marker.json
+++ b/instrumentations/memsafety/config-marker.json
@@ -641,6 +641,40 @@
                 "where": "before",
                 "in": "*"
             },
+            {
+                "findInstructions": [
+                {
+                    "returnValue": "*",
+                    "instruction": "call",
+                    "operands": ["<val>", "_exit"]
+                }
+                ],
+                "newInstruction": {
+                    "returnValue": "*",
+                    "instruction": "call",
+                    "operands": ["__INSTR_mark_exit"]
+                },
+                "conditions": [{"query":["leakcheck"], "expectedResults": ["true"]}],
+                "where": "before",
+                "in": "*"
+            },
+            {
+                "findInstructions": [
+                {
+                    "returnValue": "*",
+                    "instruction": "call",
+                    "operands": ["<val>", "_Exit"]
+                }
+                ],
+                "newInstruction": {
+                    "returnValue": "*",
+                    "instruction": "call",
+                    "operands": ["__INSTR_mark_exit"]
+                },
+                "conditions": [{"query":["leakcheck"], "expectedResults": ["true"]}],
+                "where": "before",
+                "in": "*"
+            },
 	    {
                 "findInstructions": [
                 {


### PR DESCRIPTION
New sv-benchmarks also use _exit and _Exit functions which should to be instrumented.