### PR TITLE
llvm12: Replace DebugLoc::get with DILocation::get

### DIFF
--- a/src/instr.cpp
+++ b/src/instr.cpp
@@ -309,9 +309,8 @@ bool cloneMetadata(const llvm::Instruction *i1, llvm::Instruction *i2) {
         return cloneMetadata(pred->getTerminator(), i2);
     } else {
       DebugLoc DL;
-      if (auto SP = i1->getParent()->getParent()->getSubprogram()) {
-        DL = DebugLoc::get(SP->getScopeLine(), 0, SP);
-      }
+      if (auto SP = i1->getParent()->getParent()->getSubprogram())
+        DL = DILocation::get(SP->getContext(), SP->getScopeLine(), 0, SP);
       i2->setDebugLoc(DL);
     }
 


### PR DESCRIPTION
It was removed in LLVM 12 and it has been deprecated since LLVM 3.7.