### PR TITLE
cmake: mark LLVM's include directories as `SYSTEM`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
 endif()
 
 add_definitions(${LLVM_DEFINITIONS})
-include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")


### PR DESCRIPTION
.. so that they are passed to the compiler by `-isystem` and not by `-I`.

By default both GCC and Clang ignore warnings from headers in `/usr/include`.
However, root dir for LLVM's headers on Ubuntu is `/usr/include/llvm-8` so
that's the reason why I didn't see them on my laptop and did in the CI.  This
should suppress all those annoying -Wunused-argument warnings that are not
under our control.

From CMake's documentation:

If the SYSTEM option is given, the compiler will be told the directories are
meant as system include directories on some platforms.  Signalling this
setting  might achieve effects such as the compiler skipping warnings, or these
fixed-install system files not being considered in dependency calculations -
see compiler docs.